### PR TITLE
Allow float values in bedgraph file

### DIFF
--- a/plotsr/scripts/func.py
+++ b/plotsr/scripts/func.py
@@ -581,7 +581,7 @@ class track():
             for line in fin:
                 line = line.strip().split()
                 try:
-                    v = int(line[3])
+                    v = float(line[3])
                 except ValueError:
                     if len(line) < 4:
                         self.logger.warning("Incomplete information in bedgraph file at line: {}. Skipping it.".format("\t".join(line)))


### PR DESCRIPTION
Maybe I am missing something but is there any reason to limit the bedgraph values to integers? The existing code won't import non-integer values. This change will allow bedgraph values to be floating point, not just integer. This was helpful for me, at least.